### PR TITLE
Optimization for class LEDDisplay

### DIFF
--- a/LEDDisplay.pde
+++ b/LEDDisplay.pde
@@ -160,9 +160,10 @@ public class LEDDisplay {
             b = (int)(Math.pow(b/256.0,this.gammaValue)*256);
           }
           
-          buffer[(getAddress(x, y)*3)+1] = byte(r);
-          buffer[(getAddress(x, y)*3)+2] = byte(g);
-          buffer[(getAddress(x, y)*3)+3] = byte(b);
+          int address = getAddress(x, y)*3;
+          buffer[address+1] = (byte) r;
+          buffer[address+2] = (byte) g;
+          buffer[address+3] = (byte) b;
         }
         else {
           r = int(brightness(bufPixels[y*w+x]));

--- a/LEDDisplay.pde
+++ b/LEDDisplay.pde
@@ -149,9 +149,10 @@ public class LEDDisplay {
     for (int x=0; x<w; x++) {
       for (int y=0; y<h; y++) {        
         if (isRGB) {
-          r = int(red(bufPixels[y*w+x]));
-          g = int(green(bufPixels[y*w+x]));
-          b = int(blue(bufPixels[y*w+x]));
+          color pixel = bufPixels[y * w + x];
+          r = 0xff & (pixel >> 16);
+          g = 0xff & (pixel >> 8);
+          b = 0xff & pixel;
           
           if (enableGammaCorrection) {
             r = (int)(Math.pow(r/256.0,this.gammaValue)*256);

--- a/LEDDisplay.pde
+++ b/LEDDisplay.pde
@@ -149,7 +149,7 @@ public class LEDDisplay {
     for (int x=0; x<w; x++) {
       for (int y=0; y<h; y++) {        
         if (isRGB) {
-          color pixel = bufPixels[y * w + x];
+          color pixel = bufPixels[y*w+x];
           r = 0xff & (pixel >> 16);
           g = 0xff & (pixel >> 8);
           b = 0xff & pixel;


### PR DESCRIPTION
Simple optimizations for `LEDDisplay.sendData()` inside the nested loop.

Calling `red(pixel)` is costs more than `0xff & (pixel >> 16)`. In my experience with Processing, these add up when working with larger buffers and higher frame rates, and have seen slowdown in some situations. This is just getting ahead of it.

Made a few other minor adjustments along these lines, like calling `getAddress()` once instead of three times in the inner loop. And casting directly with `(byte)` instead of calling `byte()` which is just a wrapper anyways.
